### PR TITLE
Un-parsable package_dir property

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ profile = black
 packages =
     bison-lab
 package_dir =
-    src
+    = src
 python_requires =
     >=3.10
 setup_requires =

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,9 +15,9 @@ profile = black
 
 [options]
 packages =
-    bison-lab
+    bisonlab
 package_dir =
-    = src
+    =src
 python_requires =
     >=3.10
 setup_requires =


### PR DESCRIPTION
This took some debugging. Without the preceding "=" before src setting up the Conda environment failed because setup could not parse src alone. I believe this is the proper syntax.

I run on Linux. I'm not sure if that matters in this case but either way to test you may need to remove your current Conda environment before recreating it. The error I was running into only occurred on a fresh create. 

conda env remove -n bison-lab

conda env create -f environment.yml